### PR TITLE
prevent host header injection

### DIFF
--- a/roles/ckan/templates/epos-msl-vhost.conf.j2
+++ b/roles/ckan/templates/epos-msl-vhost.conf.j2
@@ -10,6 +10,10 @@
 
 <VirtualHost *:443>
     ServerName {{ epos_msl_fqdn }}
+
+    RequestHeader set Host '{{ epos_msl_fqdn }}'
+    RequestHeader unset X-Forwarded-Host
+
     WSGIScriptAlias / /etc/ckan/default/apache.wsgi
 
     # PHP EPOS ICS API


### PR DESCRIPTION
Override Host / X-Forwarded-Host headers in order to prevent
potential host header injection issues.