### PR TITLE
YDA-6221: remove beaker which is not used in CKAN2.11 and fix http2

### DIFF
--- a/docker/images/ckan/ckan-entrypoint.sh
+++ b/docker/images/ckan/ckan-entrypoint.sh
@@ -39,11 +39,9 @@ CKAN_INIT_STATUS_FILE=/etc/ckan/default/.ckan_initialized
 if test -f "$CKAN_INIT_STATUS_FILE"
 then echo "Configuration and database already initialized."
 else echo "Initializing configuration ..."
-     export BEAKER_SESSION_SECRET=$(openssl rand -base64 32)
      export SECRET_TOKEN_VALUE=$(openssl rand -base64 32)
      export APP_INSTANCE_UUID=$(uuidgen --name "$EPOS_MSL_FQDN" --namespace "@url" --sha1)
      export CKAN_MSL_VOCABULARIES_ENDPOINT="https://${EPOS_MSL_FQDN}/webservice/api/vocabularies"
-     perl -pi.bak -e '$beaker_session_secret=$ENV{BEAKER_SESSION_SECRET}; s/BEAKER_SESSION_SECRET/$beaker_session_secret/ge' "$CKAN_CONFIG_FILE"
      perl -pi.bak -e '$secret_token=$ENV{SECRET_TOKEN_VALUE}; s/SECRET_TOKEN_VALUE/$secret_token/ge' "$CKAN_CONFIG_FILE"
      perl -pi.bak -e '$app_instance_uuid=$ENV{APP_INSTANCE_UUID}; s/APP_INSTANCE_UUID/$app_instance_uuid/ge' "$CKAN_CONFIG_FILE"
      perl -pi.bak -e '$ckan_database_password=$ENV{CKAN_DATABASE_PASSWORD}; s/CKAN_DATABASE_PASSWORD/$ckan_database_password/ge' "$CKAN_CONFIG_FILE"

--- a/docker/images/ckan/ckan.ini
+++ b/docker/images/ckan/ckan.ini
@@ -26,12 +26,6 @@ ckan.devserver.port = 5000
 
 ## Session settings
 cache_dir = /tmp/%(ckan.site_id)s/
-beaker.session.key = ckan
-
-# This is the secret token that the beaker library uses to hash the cookie sent
-# to the client. `ckan generate config` generates a unique value for this each
-# time it generates a config file.
-beaker.session.secret = BEAKER_SESSION_SECRET
 
 SECRET_KEY = SECRET_TOKEN_VALUE
 

--- a/docker/images/ckan/who.ini
+++ b/docker/images/ckan/who.ini
@@ -1,7 +1,5 @@
 [plugin:auth_tkt]
 use = ckan.lib.repoze_plugins.auth_tkt:make_plugin
-# If no secret key is defined here, beaker.session.secret will be used
-#secret = somesecret
 
 [plugin:friendlyform]
 use = ckan.lib.repoze_plugins.friendly_form:FriendlyFormPlugin

--- a/docker/images/nginx/nginx.site.part1
+++ b/docker/images/nginx/nginx.site.part1
@@ -12,8 +12,9 @@ server {
 
 server {
 
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
 
     ssl_certificate /etc/certificates/epos-msl.pem;
     ssl_certificate_key /etc/certificates/epos-msl.key;


### PR DESCRIPTION
1. Remove beaker configuration as it is not used in CKAN2.11
2. Fix for the warning:  "listen ... http2" directive is deprecated, use the "http2" directive